### PR TITLE
fix: prevent duplicate PR posts from concurrent webhook deliveries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ./go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: test.yml
+on:
+  pull_request: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: ./go.mod
+
+      - name: Test
+        run: make test-ci
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: ./go.mod
+
+      - name: Package
+        run: make dist
+
+  ci_pass:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - package
+    steps:
+      - name: check status
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/Makefile
+++ b/Makefile
@@ -200,9 +200,6 @@ ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
 else
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-linux-amd64;
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-linux-arm64;
-	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-darwin-amd64;
-	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-darwin-arm64;
-	cd server && env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) -trimpath -o dist/plugin-windows-amd64.exe;
 endif
 endif
 

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,13 @@ require (
 	github.com/google/go-github/v81 v81.0.0
 	github.com/mattermost/mattermost/server/public v0.1.21
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/beevik/etree v1.6.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dyatlov/go-opengraph/opengraph v0.0.0-20220524092352-606d7b1e5f8a // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
@@ -40,8 +42,10 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russellhaering/goxmldsig v1.5.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/tinylib/msgp v1.6.3 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "org.holochain.mm-plugin",
   "name": "Holochain",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Automate Holochain team processes by integrating with Mattermost",
   "homepage_url": "https://github.com/holochain/mm-plugin",
   "support_url": "https://github.com/holochain/mm-plugin/issues",

--- a/plugin.json
+++ b/plugin.json
@@ -10,10 +10,7 @@
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",
-      "linux-arm64": "server/dist/plugin-linux-arm64",
-      "darwin-amd64": "server/dist/plugin-darwin-amd64",
-      "darwin-arm64": "server/dist/plugin-darwin-arm64",
-      "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+      "linux-arm64": "server/dist/plugin-linux-arm64"
     }
   },
   "settings_schema": {

--- a/server/github.go
+++ b/server/github.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/cbrgm/githubevents/v2/githubevents"
 	"github.com/google/go-github/v81/github"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
 
 func (p *Plugin) startGithubEventListener() {
@@ -61,51 +63,7 @@ func (p *Plugin) startGithubEventListener() {
 
 	if teamName != "" && prFeed != "" {
 		pullRequestUpdatedHook := func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
-			repo := event.GetRepo()
-			pullRequest := event.GetPullRequest()
-
-			// Skip draft pull requests
-			if pullRequest.GetDraft() {
-				p.API.LogInfo("Pull request is a draft, skipping notification", "repo", repo.GetFullName(), "pr_number", pullRequest.GetNumber())
-				return nil
-			}
-
-			// Skip pull requests that don't have any requested reviewers
-			if (pullRequest.RequestedTeams == nil || len(pullRequest.RequestedTeams) == 0) && (pullRequest.RequestedReviewers == nil || len(pullRequest.RequestedReviewers) == 0) {
-				p.API.LogInfo("Pull request has no requested reviewers or teams, skipping notification", "repo", repo.GetFullName(), "pr_number", pullRequest.GetNumber())
-				return nil
-			}
-
-			if err := p.validateRepoProperties(repo, event); err != nil {
-				return err
-			}
-
-			tag := fmt.Sprintf("#%s.%s.%d", repo.GetOwner().GetLogin(), repo.GetName(), pullRequest.GetNumber())
-			posts, err := p.findPostsByTag(tag, teamName, prFeed)
-			if err != nil {
-				return fmt.Errorf("failed to find posts by tag %s: %w", tag, err)
-			}
-
-			if len(posts) > 0 {
-				// Ensure that the post is pinned
-				for _, post := range posts {
-					if !post.IsPinned {
-						post.IsPinned = true
-						err = p.client.Post.UpdatePost(post)
-						if err != nil {
-							return fmt.Errorf("failed to update post in channel %s: %w", prFeed, err)
-						}
-					}
-				}
-
-				// Pull request message already exists, do not send a duplicate
-				return nil
-			}
-
-			return p.sendMessage(
-				fmt.Sprintf("%s\n%s\n%s", pullRequest.GetTitle(), pullRequest.GetHTMLURL(), tag),
-				teamName,
-				prFeed, true)
+			return p.handlePullRequestUpdated(teamName, prFeed, event)
 		}
 
 		eventHandler.OnPullRequestEventOpened(pullRequestUpdatedHook)
@@ -185,6 +143,108 @@ func (p *Plugin) startGithubEventListener() {
 	}
 
 	p.eventHandler = eventHandler
+}
+
+// handlePullRequestUpdated decides whether a pull request should be posted (or re-pinned) to
+// Mattermost. GitHub can deliver multiple webhook events for the same pull request in quick
+// succession (e.g. "opened" and "review_requested" when a non-draft PR is created with reviewers
+// already assigned), and each delivery is handled on its own goroutine with no coordination
+// between them. To avoid posting the same pull request twice, creating the post is gated behind
+// an atomic claim so only one concurrent delivery actually creates it.
+func (p *Plugin) handlePullRequestUpdated(teamName, prFeed string, event *github.PullRequestEvent) error {
+	repo := event.GetRepo()
+	pullRequest := event.GetPullRequest()
+
+	// Skip draft pull requests
+	if pullRequest.GetDraft() {
+		p.API.LogInfo("Pull request is a draft, skipping notification", "repo", repo.GetFullName(), "pr_number", pullRequest.GetNumber())
+		return nil
+	}
+
+	// Skip pull requests that don't have any requested reviewers
+	if (pullRequest.RequestedTeams == nil || len(pullRequest.RequestedTeams) == 0) && (pullRequest.RequestedReviewers == nil || len(pullRequest.RequestedReviewers) == 0) {
+		p.API.LogInfo("Pull request has no requested reviewers or teams, skipping notification", "repo", repo.GetFullName(), "pr_number", pullRequest.GetNumber())
+		return nil
+	}
+
+	if err := p.validateRepoProperties(repo, event); err != nil {
+		return err
+	}
+
+	tag := fmt.Sprintf("#%s.%s.%d", repo.GetOwner().GetLogin(), repo.GetName(), pullRequest.GetNumber())
+	posts, err := p.findPostsByTag(tag, teamName, prFeed)
+	if err != nil {
+		return fmt.Errorf("failed to find posts by tag %s: %w", tag, err)
+	}
+
+	if len(posts) > 0 {
+		// Ensure that the post is pinned
+		for _, post := range posts {
+			if !post.IsPinned {
+				post.IsPinned = true
+				err = p.client.Post.UpdatePost(post)
+				if err != nil {
+					return fmt.Errorf("failed to update post in channel %s: %w", prFeed, err)
+				}
+			}
+		}
+
+		// Pull request message already exists, do not send a duplicate
+		return nil
+	}
+
+	// Multiple webhook deliveries for this pull request can reach this point having each seen no
+	// existing post. Only the delivery that wins this atomic claim is allowed to create it.
+	claimed, err := p.tryClaimPost(tag)
+	if err != nil {
+		return fmt.Errorf("failed to claim post for tag %s: %w", tag, err)
+	}
+	if !claimed {
+		p.API.LogInfo("Pull request post already claimed by another event, skipping duplicate", "tag", tag)
+		return nil
+	}
+
+	if err := p.sendMessage(
+		fmt.Sprintf("%s\n%s\n%s", pullRequest.GetTitle(), pullRequest.GetHTMLURL(), tag),
+		teamName,
+		prFeed, true); err != nil {
+		// Posting failed, so release the claim to allow a future event to retry.
+		p.releasePostClaim(tag)
+		return err
+	}
+
+	return nil
+}
+
+// postClaimTTL bounds how long a post claim occupies the KV store. It only needs to outlive the
+// window where a concurrent or slightly delayed duplicate delivery could still be racing against
+// the original one (near-simultaneous webhook deliveries, Mattermost search-index lag on the
+// findPostsByTag check). Once that window has passed, findPostsByTag itself is the authoritative
+// record that the pull request was already posted, so the claim no longer needs to exist.
+const postClaimTTL = time.Hour
+
+// tryClaimPost atomically claims the right to create the Mattermost post identified by tag.
+// It returns true only for the single caller that wins the race for a given tag; all other
+// concurrent or subsequent callers receive false and must not post again. The claim expires
+// after postClaimTTL so successful claims don't accumulate in the KV store indefinitely.
+func (p *Plugin) tryClaimPost(tag string) (bool, error) {
+	claimed, err := p.client.KV.Set(postClaimKey(tag), true, pluginapi.SetAtomic(nil), pluginapi.SetExpiry(postClaimTTL))
+	if err != nil {
+		return false, err
+	}
+	return claimed, nil
+}
+
+// releasePostClaim releases a claim taken by tryClaimPost, allowing a future event for the same
+// tag to retry after a failed post.
+func (p *Plugin) releasePostClaim(tag string) {
+	if err := p.client.KV.Delete(postClaimKey(tag)); err != nil {
+		p.API.LogWarn("failed to release post claim", "tag", tag, "err", err)
+	}
+}
+
+func postClaimKey(tag string) string {
+	return "post-claim:" + tag
 }
 
 func releaseTable(repo *github.Repository, release *github.RepositoryRelease, isPreRelease bool) string {

--- a/server/github_test.go
+++ b/server/github_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v81/github"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeKVStore backs a plugintest.API's KVSetWithOptions/KVDelete with real atomic
+// compare-and-set semantics (mutex-guarded map), the same contract the real Mattermost
+// server provides, so concurrency tests exercise genuine race behavior rather than a
+// canned mock response.
+type fakeKVStore struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func (f *fakeKVStore) set(key string, value []byte, opts model.PluginKVSetOptions) (bool, *model.AppError) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.data == nil {
+		f.data = make(map[string][]byte)
+	}
+
+	if opts.Atomic {
+		existing, ok := f.data[key]
+		if opts.OldValue == nil {
+			if ok {
+				return false, nil
+			}
+		} else if !ok || !bytes.Equal(existing, opts.OldValue) {
+			return false, nil
+		}
+	}
+
+	f.data[key] = value
+	return true, nil
+}
+
+func (f *fakeKVStore) delete(key string) *model.AppError {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.data, key)
+	return nil
+}
+
+// TestTryClaimPost_OnlyOneWinnerUnderConcurrency proves the atomic claim used to gate PR
+// post creation genuinely allows only one winner when many goroutines race for the same tag.
+func TestTryClaimPost_OnlyOneWinnerUnderConcurrency(t *testing.T) {
+	store := &fakeKVStore{}
+	mockAPI := &plugintest.API{}
+	mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(store.set)
+
+	p := &Plugin{}
+	p.API = mockAPI
+	p.client = pluginapi.NewClient(mockAPI, nil)
+
+	const concurrency = 20
+	results := make([]bool, concurrency)
+
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := range concurrency {
+		go func(i int) {
+			defer wg.Done()
+			claimed, err := p.tryClaimPost("#owner.repo.1")
+			require.NoError(t, err)
+			results[i] = claimed
+		}(i)
+	}
+	wg.Wait()
+
+	winners := 0
+	for _, claimed := range results {
+		if claimed {
+			winners++
+		}
+	}
+
+	require.Equal(t, 1, winners, "expected exactly one goroutine to win the claim, got %d", winners)
+}
+
+// TestTryClaimPost_SetsExpiry ensures claims don't accumulate in the KV store forever: a
+// successful claim must carry the postClaimTTL expiry, not persist indefinitely.
+func TestTryClaimPost_SetsExpiry(t *testing.T) {
+	mockAPI := &plugintest.API{}
+
+	var gotOptions model.PluginKVSetOptions
+	mockAPI.On("KVSetWithOptions", "post-claim:#owner.repo.1", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			gotOptions = args.Get(2).(model.PluginKVSetOptions)
+		}).
+		Return(true, nil)
+
+	p := &Plugin{}
+	p.API = mockAPI
+	p.client = pluginapi.NewClient(mockAPI, nil)
+
+	claimed, err := p.tryClaimPost("#owner.repo.1")
+	require.NoError(t, err)
+	require.True(t, claimed)
+
+	require.True(t, gotOptions.Atomic)
+	require.Nil(t, gotOptions.OldValue)
+	require.Equal(t, int64(postClaimTTL/time.Second), gotOptions.ExpireInSeconds)
+}
+
+// TestHandlePullRequestUpdated_DoesNotDoublePost reproduces the reported bug: GitHub sends
+// two webhook deliveries in quick succession for the same non-draft, reviewer-assigned pull
+// request (e.g. "opened" and "review_requested"), and both are handled concurrently. Before
+// the fix, both deliveries would observe no existing Mattermost post and both would call
+// CreatePost, pinning the PR twice. After the fix, only one delivery should ever post.
+func TestHandlePullRequestUpdated_DoesNotDoublePost(t *testing.T) {
+	store := &fakeKVStore{}
+	mockAPI := &plugintest.API{}
+
+	botUserId := "bot-id"
+	team := &model.Team{Id: "team-id", Name: "team"}
+	channel := &model.Channel{Id: "channel-id", Name: "pr-feed"}
+
+	mockAPI.On("GetTeamByName", "team").Return(team, nil)
+	mockAPI.On("GetTeamMembers", "team-id", 0, 100).
+		Return([]*model.TeamMember{{TeamId: "team-id", UserId: botUserId}}, nil)
+	mockAPI.On("GetChannelByName", "team-id", "pr-feed", false).Return(channel, nil)
+	mockAPI.On("SearchPostsInTeam", "team-id", mock.Anything).Return([]*model.Post{}, nil)
+	mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(store.set)
+	mockAPI.On("CreatePost", mock.Anything).Return(&model.Post{Id: "post-id"}, nil)
+	mockAPI.On("LogInfo", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	p := &Plugin{}
+	p.API = mockAPI
+	p.client = pluginapi.NewClient(mockAPI, nil)
+	p.botUserId = &botUserId
+
+	event := &github.PullRequestEvent{
+		Repo: &github.Repository{
+			Owner: &github.User{Login: github.Ptr("owner")},
+			Name:  github.Ptr("repo"),
+		},
+		PullRequest: &github.PullRequest{
+			Number:             github.Ptr(1),
+			Title:              github.Ptr("Some PR"),
+			HTMLURL:            github.Ptr("https://github.com/owner/repo/pull/1"),
+			Draft:              github.Ptr(false),
+			RequestedReviewers: []*github.User{{Login: github.Ptr("reviewer")}},
+		},
+	}
+
+	// Simulate two concurrent webhook deliveries for the same pull request.
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	for i := range 2 {
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = p.handlePullRequestUpdated("team", "pr-feed", event)
+		}(i)
+	}
+	wg.Wait()
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+	mockAPI.AssertNumberOfCalls(t, "CreatePost", 1)
+}


### PR DESCRIPTION
closes https://github.com/holochain/hc-mattermost-bot/issues/6

## Summary
- GitHub can send multiple webhook deliveries for the same pull request in quick succession (e.g. `opened` + `review_requested` when a non-draft PR is created with reviewers already assigned). Each delivery was handled on its own goroutine with no coordination, so both could see no existing Mattermost post via `findPostsByTag` and both would call `sendMessage`/`CreatePost`, posting and pinning the PR twice.
- Extracted the pull request hook into `handlePullRequestUpdated` and added `tryClaimPost`/`releasePostClaim`, which use the Mattermost plugin KV store's atomic compare-and-set (`KVSetWithOptions` with `Atomic` + `OldValue == nil`) to gate post creation — only the delivery that wins the atomic insert is allowed to post. This also holds up correctly under Mattermost HA (multiple plugin instances), unlike an in-process mutex.
- If `sendMessage` fails after winning the claim, the claim is released so a later event can retry instead of being permanently blocked.
- The claim expires after 1 hour (`pluginapi.SetExpiry`) so successful claims don't accumulate in the KV store indefinitely; that window comfortably covers the real race (near-simultaneous deliveries, Mattermost search-index lag) without keeping stale entries forever.
